### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "viewone/wp-cli-environment",
   "license": "MIT",
   "description": "Environment package for wp-cli",
+  "type": "wp-cli-package",
   "authors": [
     {
       "name": "Piotr Kierzniewski",


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
